### PR TITLE
21 stop archers from dealing damage to player structures

### DIFF
--- a/FriendlySkeletonWand/Assets/chebgonaz.manifest
+++ b/FriendlySkeletonWand/Assets/chebgonaz.manifest
@@ -1,9 +1,9 @@
 ManifestFileVersion: 0
-CRC: 3560796974
+CRC: 2839071219
 Hashes:
   AssetFileHash:
     serializedVersion: 2
-    Hash: 1c91d595143a77258e036d30076f01bb
+    Hash: 8d3ee2b1223a94cd785b409141c5ba0e
   TypeTreeHash:
     serializedVersion: 2
     Hash: 80481c417d4ed3cc366bc5ad63973d7e

--- a/FriendlySkeletonWand/Assets/chebgonaz.manifest
+++ b/FriendlySkeletonWand/Assets/chebgonaz.manifest
@@ -1,9 +1,9 @@
 ManifestFileVersion: 0
-CRC: 2839071219
+CRC: 3560796974
 Hashes:
   AssetFileHash:
     serializedVersion: 2
-    Hash: 8d3ee2b1223a94cd785b409141c5ba0e
+    Hash: 1c91d595143a77258e036d30076f01bb
   TypeTreeHash:
     serializedVersion: 2
     Hash: 80481c417d4ed3cc366bc5ad63973d7e

--- a/FriendlySkeletonWand/BasePlugin.cs
+++ b/FriendlySkeletonWand/BasePlugin.cs
@@ -423,26 +423,30 @@ namespace FriendlySkeletonWand
         }
     }
 
-    [HarmonyPatch(typeof(Projectile))]
+    [HarmonyPatch(typeof(WearNTear), "RPC_Damage")]
     static class ArrowImpactPatch
     {
-        [HarmonyPrefix]
-        [HarmonyPatch(nameof(Projectile.OnHit))]
-        static bool OnHitPrefix(ref Collider collider, ref Vector3 hitPoint, ref bool water, ref Projectile __instance)
+        // stop minions from damaging player structures
+        static void Prefix(ref HitData hit, Piece ___m_piece)
         {
-            // stop player structure damage from minion arrows
-            if (__instance.m_owner.GetComponent<UndeadMinion>() != null)
+            if (hit.GetAttacker().TryGetComponent(out UndeadMinion undeadMinion))
             {
-                if (collider.TryGetComponent(out Piece piece))
+                if (___m_piece.IsPlacedByPlayer())
                 {
-                    if (piece.IsPlacedByPlayer())
-                    {
-                        Jotunn.Logger.LogInfo($"Projectile colliding with {piece.name} and returning false");
-                        return false;
-                    }
+                    Jotunn.Logger.LogInfo($"Projectile colliding with {___m_piece.name}, setting damage to 0");
+                    hit.m_damage.m_damage = 0f;
+                    hit.m_damage.m_blunt = 0f;
+                    hit.m_damage.m_slash = 0f;
+                    hit.m_damage.m_pierce = 0f;
+                    hit.m_damage.m_chop = 0f;
+                    hit.m_damage.m_pickaxe = 0f;
+                    hit.m_damage.m_fire = 0f;
+                    hit.m_damage.m_frost = 0f;
+                    hit.m_damage.m_lightning = 0f;
+                    hit.m_damage.m_poison = 0f;
+                    hit.m_damage.m_spirit = 0f;
                 }
             }
-            return true;
         }
     }
     #endregion

--- a/FriendlySkeletonWand/BasePlugin.cs
+++ b/FriendlySkeletonWand/BasePlugin.cs
@@ -422,6 +422,66 @@ namespace FriendlySkeletonWand
             }
         }
     }
+
+    [HarmonyPatch(typeof(Projectile))]
+    static class ArrowImpactPatch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(Projectile.OnHit))]
+        static void OnHitPrefix(ref Collider __collider, ref Vector3 __hitPoint, ref bool __water)
+        {
+            // stop player structure damage from minion arrows
+            //if (__collider.TryGetComponent(out Piece piece)) // screws up Harmony, too bad: https://github.com/pardeike/Harmony/issues/3
+            Piece piece = __collider.GetComponent<Piece>();
+            if (piece != null)
+            {
+                if (piece.IsPlacedByPlayer())
+                {
+                    Jotunn.Logger.LogInfo($"Projectile colliding with {piece.name}");
+                    return;
+                }
+            }
+        }
+    }
+
+    //[HarmonyPatch(typeof(Projectile))]
+    //static class ArrowImpactPatch
+    //{
+        //[HarmonyPrefix]
+        //[HarmonyPatch(nameof(Projectile.IsValidTarget))]
+        //static void IsValidTargetPrefix(ref IDestructible __destr)
+        //{
+        //    // stop player structure damage from minion arrows
+
+        //    if (m_owner)
+        //    //Character character = destr as Character;
+        //    //if (Object.op_Implicit((Object)(object)character))
+        //    //{
+        //    //    if ((Object)(object)character == (Object)(object)m_owner)
+        //    //    {
+        //    //        return false;
+        //    //    }
+        //    //    if ((Object)(object)m_owner != (Object)null)
+        //    //    {
+        //    //        bool flag = BaseAI.IsEnemy(m_owner, character) || (Object.op_Implicit((Object)(object)character.GetBaseAI()) && character.GetBaseAI().IsAggravatable() && m_owner.IsPlayer());
+        //    //        if (!m_owner.IsPlayer() && !flag)
+        //    //        {
+        //    //            return false;
+        //    //        }
+        //    //        if (m_owner.IsPlayer() && !m_owner.IsPVPEnabled() && !flag)
+        //    //        {
+        //    //            return false;
+        //    //        }
+        //    //    }
+        //    //    if (m_dodgeable && character.IsDodgeInvincible())
+        //    //    {
+        //    //        return false;
+        //    //    }
+        //    //}
+        //    //return true;
+
+        //}
+    //}
     #endregion
 }
 

--- a/FriendlySkeletonWand/BasePlugin.cs
+++ b/FriendlySkeletonWand/BasePlugin.cs
@@ -428,60 +428,22 @@ namespace FriendlySkeletonWand
     {
         [HarmonyPrefix]
         [HarmonyPatch(nameof(Projectile.OnHit))]
-        static void OnHitPrefix(ref Collider __collider, ref Vector3 __hitPoint, ref bool __water)
+        static void OnHitPrefix(ref Collider collider, ref Vector3 hitPoint, ref bool water, ref Projectile __instance)
         {
             // stop player structure damage from minion arrows
-            //if (__collider.TryGetComponent(out Piece piece)) // screws up Harmony, too bad: https://github.com/pardeike/Harmony/issues/3
-            Piece piece = __collider.GetComponent<Piece>();
-            if (piece != null)
+            if (__instance.m_owner.GetComponent<UndeadMinion>() != null)
             {
-                if (piece.IsPlacedByPlayer())
+                if (collider.TryGetComponent(out Piece piece))
                 {
-                    Jotunn.Logger.LogInfo($"Projectile colliding with {piece.name}");
-                    return;
+                    if (piece.IsPlacedByPlayer())
+                    {
+                        Jotunn.Logger.LogInfo($"Projectile colliding with {piece.name}");
+                        return;
+                    }
                 }
             }
         }
     }
-
-    //[HarmonyPatch(typeof(Projectile))]
-    //static class ArrowImpactPatch
-    //{
-        //[HarmonyPrefix]
-        //[HarmonyPatch(nameof(Projectile.IsValidTarget))]
-        //static void IsValidTargetPrefix(ref IDestructible __destr)
-        //{
-        //    // stop player structure damage from minion arrows
-
-        //    if (m_owner)
-        //    //Character character = destr as Character;
-        //    //if (Object.op_Implicit((Object)(object)character))
-        //    //{
-        //    //    if ((Object)(object)character == (Object)(object)m_owner)
-        //    //    {
-        //    //        return false;
-        //    //    }
-        //    //    if ((Object)(object)m_owner != (Object)null)
-        //    //    {
-        //    //        bool flag = BaseAI.IsEnemy(m_owner, character) || (Object.op_Implicit((Object)(object)character.GetBaseAI()) && character.GetBaseAI().IsAggravatable() && m_owner.IsPlayer());
-        //    //        if (!m_owner.IsPlayer() && !flag)
-        //    //        {
-        //    //            return false;
-        //    //        }
-        //    //        if (m_owner.IsPlayer() && !m_owner.IsPVPEnabled() && !flag)
-        //    //        {
-        //    //            return false;
-        //    //        }
-        //    //    }
-        //    //    if (m_dodgeable && character.IsDodgeInvincible())
-        //    //    {
-        //    //        return false;
-        //    //    }
-        //    //}
-        //    //return true;
-
-        //}
-    //}
     #endregion
 }
 

--- a/FriendlySkeletonWand/BasePlugin.cs
+++ b/FriendlySkeletonWand/BasePlugin.cs
@@ -428,7 +428,7 @@ namespace FriendlySkeletonWand
     {
         [HarmonyPrefix]
         [HarmonyPatch(nameof(Projectile.OnHit))]
-        static void OnHitPrefix(ref Collider collider, ref Vector3 hitPoint, ref bool water, ref Projectile __instance)
+        static bool OnHitPrefix(ref Collider collider, ref Vector3 hitPoint, ref bool water, ref Projectile __instance)
         {
             // stop player structure damage from minion arrows
             if (__instance.m_owner.GetComponent<UndeadMinion>() != null)
@@ -437,11 +437,12 @@ namespace FriendlySkeletonWand
                 {
                     if (piece.IsPlacedByPlayer())
                     {
-                        Jotunn.Logger.LogInfo($"Projectile colliding with {piece.name}");
-                        return;
+                        Jotunn.Logger.LogInfo($"Projectile colliding with {piece.name} and returning false");
+                        return false;
                     }
                 }
             }
+            return true;
         }
     }
     #endregion


### PR DESCRIPTION
# Description

Add a Harmony patch to intercept a projectile collision with a player structure and stop it from damaging it.

## Important

- When merging, if changes are present, omit `chebgonaz` and `chebgonaz.manifest`. We only want `BasePlugin.cs`'s changes

## Testing instructions

Please set up some kind of situation where skeleton or draugr archers shoot a player owned structure and ensure no damage is dealt. This can be tricky to set up. A good way I found:

1. Make a tower
2. Add fences around the top of tower
3. Put skele/draugr archers in tower
4. put greylings ont he floor around tower
5. the minions will shoot at greylings and occasionally hit the fences. The greylings wont damage the fences due to having no ranged attack of their own
6. if the arrows are damaging the player structure, it's not working

Please test well because I'm not 100% sure this is working... if it is working, we can remove the log message from within the harmony patch