### PR TITLE
32 skeleton armor values forgotten after logoutlogin

### DIFF
--- a/FriendlySkeletonWand/BasePlugin.cs
+++ b/FriendlySkeletonWand/BasePlugin.cs
@@ -30,7 +30,7 @@ namespace FriendlySkeletonWand
     {
         public const string PluginGUID = "com.chebgonaz.FriendlySkeletonWand";
         public const string PluginName = "FriendlySkeletonWand";
-        public const string PluginVersion = "1.4.0";
+        public const string PluginVersion = "1.4.1";
 
         private readonly Harmony harmony = new Harmony(PluginGUID);
 
@@ -99,6 +99,8 @@ namespace FriendlySkeletonWand
                 #endregion
 
                 #region Items
+                // by great Cthulhu, this needs refactoring!
+                //
                 GameObject spectralShroudPrefab = LoadPrefabFromBundle(spectralShroudItem.PrefabName, chebgonazAssetBundle);
                 ItemManager.Instance.AddItem(spectralShroudItem.GetCustomItemFromPrefab(spectralShroudPrefab));
 

--- a/FriendlySkeletonWand/Minions/SkeletonMinion.cs
+++ b/FriendlySkeletonWand/Minions/SkeletonMinion.cs
@@ -43,7 +43,26 @@ namespace FriendlySkeletonWand.Minions
             // by the time player arrives, ZNet stuff is certainly ready
             if (TryGetComponent(out Humanoid humanoid))
             {
-                humanoid.GiveDefaultItems();
+                // VisEquipment remembers what armor the skeleton is wearing.
+                // Exploit this to reapply the armor so the armor values work
+                // again.
+                List<int> equipmentHashes = new List<int>()
+                {
+                    humanoid.m_visEquipment.m_currentChestItemHash,
+                    humanoid.m_visEquipment.m_currentLegItemHash,
+                    humanoid.m_visEquipment.m_currentHelmetItemHash
+                };
+                equipmentHashes.ForEach(hash =>
+                {
+                    ZNetScene.instance.GetPrefab(hash);
+
+                    GameObject equipmentPrefab = ZNetScene.instance.GetPrefab(hash);
+                    if (equipmentPrefab != null)
+                    {
+                        //Jotunn.Logger.LogInfo($"Giving default item {equipmentPrefab.name}");
+                        humanoid.GiveDefaultItem(equipmentPrefab);
+                    }
+                });
             }
         }
 

--- a/FriendlySkeletonWand/Package/README.md
+++ b/FriendlySkeletonWand/Package/README.md
@@ -16,6 +16,15 @@ I'm a YouTuber/Game Developer/Modder who is interested in all things necromancy 
 
 Thank you and I hope you enjoy the mod! If you have questions or need help please join my [Discord](https://discord.com/invite/EB96ASQ).
 
+## Reporting Bugs & Requesting Features
+
+If you would like to report a bug or request a feature, the best way to do it (in order from most preferable to least preferable) is:
+
+a) Create an issue on my [GitHub](https://github.com/jpw1991/Friendly-Skeleton-Wand).
+b) Create a bug report on the [Nexus page](https://www.nexusmods.com/valheim/mods/2040?tab=bugs).
+c) Write to me on [Discord](https://discord.com/invite/EB96ASQ).
+d) Write a comment on the [Nexus page](https://www.nexusmods.com/valheim/mods/2040?tab=posts).
+
 ## Requirements
 
 - Valheim Mistlands
@@ -89,6 +98,7 @@ A: Make sure your necromancy level is high enough and have some Guck in your inv
 
 Date | Version | Notes
 --- | --- | ---
+09/01/2023 | 1.4.1 | Fix minions not remembering their armor values
 09/01/2023 | 1.4.0 | Minions no longer damage player structures; armor values actually applied to skeletons (although not remembered on logoff/login again - will fix soon); add necroneck gatherer
 07/01/2023 | 1.3.0 | Add server sync so that clients must use the configuration options of the server
 07/01/2023 | 1.2.1 | Add black iron armor; permit skeletons to use black iron armor; rebalance spirit pylon by introducing a delay and a limit (both configurable)
@@ -139,7 +149,8 @@ You can find the github [here](https://github.com/jpw1991/Friendly-Skeleton-Wand
 
 ## Special Thanks
 
-- Dracbjorn for development help & testing
-- S970X for making the German language localization for the mod.
-- Ramblez for texturing help
+- **Dracbjorn** for development help & testing
+- **S970X** for making the German language localization for the mod.
+- **Ramblez** for texturing help
+- **redseiko** for helpful advice on the official Valheim modding Discord.
 

--- a/FriendlySkeletonWand/Package/README.md
+++ b/FriendlySkeletonWand/Package/README.md
@@ -2,6 +2,8 @@
 
 This mod adds a craftable wand which can be used to create skeletons with. These skeletons are supposed to guard your base and hang around the general vicinity of wherever you create them.
 
+**Pre-release versions:** To get the latest improvements but with less testing, check the [GitHub's releases page](https://github.com/jpw1991/Friendly-Skeleton-Wand/releases). Although less tested than the official releases, they are still tested pretty well.
+
 ## Important Update Note for pre-1.0.8
 
 <details><summary>If you are upgrading from 1.0.7 or lower, your skeletons will still be there but you won't be able to command them anymore! <b>This is not a bug.</b></summary>The old skeletons used the existing Mistlands `Skeleton_Friendly` prefab which belongs to Blood Magic. In 1.0.8 these have been replaced with my own custom prefabs: `ChebGonaz_SkeletonWarrior` and `ChebGonaz_SkeletonArcher`. This gives you the control to choose either kind, instead of it being random, and also stops Blood Magic from levelling up from this mod.</details>

--- a/FriendlySkeletonWand/Package/manifest.json
+++ b/FriendlySkeletonWand/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "FriendlySkeletonWand",
   "description": "Adds craftable wands that can be used to create friendly skeletons and draugr to follow you and guard your base with.",
-  "version_number": "1.4.0",
+  "version_number": "1.4.1",
   "website_url": "chebgonaz.pythonanywhere.com",
   "dependencies": [
     "ValheimModding-Jotunn-2.10.0"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This mod adds a craftable wand which can be used to create skeletons with. These skeletons are supposed to guard your base and hang around the general vicinity of wherever you create them.
 
+**Pre-release versions:** To get the latest improvements but with less testing, check the [GitHub's releases page](https://github.com/jpw1991/Friendly-Skeleton-Wand/releases). Although less tested than the official releases, they are still tested pretty well.
+
 ## Important Update Note for pre-1.0.8
 
 <details><summary>If you are upgrading from 1.0.7 or lower, your skeletons will still be there but you won't be able to command them anymore! <b>This is not a bug.</b></summary>The old skeletons used the existing Mistlands `Skeleton_Friendly` prefab which belongs to Blood Magic. In 1.0.8 these have been replaced with my own custom prefabs: `ChebGonaz_SkeletonWarrior` and `ChebGonaz_SkeletonArcher`. This gives you the control to choose either kind, instead of it being random, and also stops Blood Magic from levelling up from this mod.</details>

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ A: Make sure your necromancy level is high enough and have some Guck in your inv
 
 Date | Version | Notes
 --- | --- | ---
+09/01/2023 | 1.4.1 | Fix minions not remembering their armor values
 09/01/2023 | 1.4.0 | Minions no longer damage player structures; armor values actually applied to skeletons (although not remembered on logoff/login again - will fix soon); add necroneck gatherer
 07/01/2023 | 1.3.0 | Add server sync so that clients must use the configuration options of the server
 07/01/2023 | 1.2.1 | Add black iron armor; permit skeletons to use black iron armor; rebalance spirit pylon by introducing a delay and a limit (both configurable)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ I'm a YouTuber/Game Developer/Modder who is interested in all things necromancy 
 
 Thank you and I hope you enjoy the mod! If you have questions or need help please join my [Discord](https://discord.com/invite/EB96ASQ).
 
+## Reporting Bugs & Requesting Features
+
+If you would like to report a bug or request a feature, the best way to do it (in order from most preferable to least preferable) is:
+
+a) Create an issue on my [GitHub](https://github.com/jpw1991/Friendly-Skeleton-Wand).
+b) Create a bug report on the [Nexus page](https://www.nexusmods.com/valheim/mods/2040?tab=bugs).
+c) Write to me on [Discord](https://discord.com/invite/EB96ASQ).
+d) Write a comment on the [Nexus page](https://www.nexusmods.com/valheim/mods/2040?tab=posts).
+
 ## Requirements
 
 - Valheim Mistlands
@@ -139,7 +148,8 @@ You can find the github [here](https://github.com/jpw1991/Friendly-Skeleton-Wand
 
 ## Special Thanks
 
-- Dracbjorn for development help & testing
-- S970X for making the German language localization for the mod.
-- Ramblez for texturing help
+- **Dracbjorn** for development help & testing
+- **S970X** for making the German language localization for the mod.
+- **Ramblez** for texturing help
+- **redseiko** for helpful advice on the official Valheim modding Discord.
 


### PR DESCRIPTION
# Description

Fix a bug where skeleton armor values are forgotten after logout/login

## Testing

1. create a mixture of skeletons with armor
2. let some creatures hit them, confirm that the log reports something like: `[Info   :FriendlySkeletonWand.CharacterGetDamageModifiersPatch] ChebGonaz_SkeletonWarriorTier3(Clone) applied body armor 84` to confirm that their armor values are being applied
3. log out, or better, quit to desktop
4. log back in
5. let some creatures hit those same skeletons again
6. confirm that the log reports that the armor is still being applied with the same value. If it says 0 then it's still bugged (which should be impossible now!)

### Checklist

- [ ] naked skeletons have 0 armor
- [ ] leather skeletons remember their armor
- [ ] bronze  skeletons remember their armor
- [ ] iron  skeletons remember their armor
- [ ] black metal  skeletons remember their armor