### PR TITLE
add some extra null checking to prevent occasional null object error

### DIFF
--- a/FriendlySkeletonWand/BasePlugin.cs
+++ b/FriendlySkeletonWand/BasePlugin.cs
@@ -422,21 +422,26 @@ namespace FriendlySkeletonWand
         // stop minions from damaging player structures
         static void Prefix(ref HitData hit, Piece ___m_piece)
         {
-            if (hit.GetAttacker().TryGetComponent(out UndeadMinion undeadMinion))
+            if (hit != null)
             {
-                if (___m_piece.IsPlacedByPlayer())
+                Character attacker = hit.GetAttacker();
+                if (attacker != null 
+                    && attacker.TryGetComponent(out UndeadMinion undeadMinion))
                 {
-                    hit.m_damage.m_damage = 0f;
-                    hit.m_damage.m_blunt = 0f;
-                    hit.m_damage.m_slash = 0f;
-                    hit.m_damage.m_pierce = 0f;
-                    hit.m_damage.m_chop = 0f;
-                    hit.m_damage.m_pickaxe = 0f;
-                    hit.m_damage.m_fire = 0f;
-                    hit.m_damage.m_frost = 0f;
-                    hit.m_damage.m_lightning = 0f;
-                    hit.m_damage.m_poison = 0f;
-                    hit.m_damage.m_spirit = 0f;
+                    if (___m_piece.IsPlacedByPlayer())
+                    {
+                        hit.m_damage.m_damage = 0f;
+                        hit.m_damage.m_blunt = 0f;
+                        hit.m_damage.m_slash = 0f;
+                        hit.m_damage.m_pierce = 0f;
+                        hit.m_damage.m_chop = 0f;
+                        hit.m_damage.m_pickaxe = 0f;
+                        hit.m_damage.m_fire = 0f;
+                        hit.m_damage.m_frost = 0f;
+                        hit.m_damage.m_lightning = 0f;
+                        hit.m_damage.m_poison = 0f;
+                        hit.m_damage.m_spirit = 0f;
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description

Add some checks to prevent null object exception

## Testing

1. Engineer some kind of crazy situation where minions are dealing all kinds of damage to a player structure (particularly with arrows, but also in general)
2. After a decent play session, check the log for errors like:

> [Error  : Unity Log] NullReferenceException: Object reference not set to an instance of an object
Stack trace:
FriendlySkeletonWand.ArrowImpactPatch.Prefix (HitData& hit, Piece ___m_piece) (at <0c8a0956dd0d4b1eb1dcd1463f6cd24c>:0)
(wrapper dynamic-method) WearNTear.DMD<WearNTear::RPC_Damage>(WearNTear,long,HitData)
System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <695d1cc93cca45069c528c15c9fdd749>:0)
Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <695d1cc93cca45069c528c15c9fdd749>:0)
System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) (at <695d1cc93cca45069c528c15c9fdd749>:0)
System.Delegate.DynamicInvokeImpl (System.Object[] args) (at <695d1cc93cca45069c528c15c9fdd749>:0)
System.MulticastDelegate.DynamicInvokeImpl (System.Object[] args) (at <695d1cc93cca45069c528c15c9fdd749>:0)
System.Delegate.DynamicInvoke (System.Object[] args) (at <695d1cc93cca45069c528c15c9fdd749>:0)
RoutedMethod`1[T].Invoke (System.Int64 rpc, ZPackage pkg) (at <35c0f7aa1999477788815a7bf78200d7>:0)
ZNetView.HandleRoutedRPC (ZRoutedRpc+RoutedRPCData rpcData) (at <35c0f7aa1999477788815a7bf78200d7>:0)
ZRoutedRpc.HandleRoutedRPC (ZRoutedRpc+RoutedRPCData data) (at <35c0f7aa1999477788815a7bf78200d7>:0)
ZRoutedRpc.InvokeRoutedRPC (System.Int64 targetPeerID, ZDOID targetZDO, System.String methodName, System.Object[] parameters) (at <35c0f7aa1999477788815a7bf78200d7>:0)
ZNetView.InvokeRPC (System.String method, System.Object[] parameters) (at <35c0f7aa1999477788815a7bf78200d7>:0)
WearNTear.Damage (HitData hit) (at <35c0f7aa1999477788815a7bf78200d7>:0)
Aoe.OnHit (UnityEngine.Collider collider, UnityEngine.Vector3 hitPoint) (at <35c0f7aa1999477788815a7bf78200d7>:0)
Aoe.OnTriggerStay (UnityEngine.Collider collider) (at <35c0f7aa1999477788815a7bf78200d7>:0)

## Checklist

- [ ] error did not occur after a little while playing with minions hitting player structures